### PR TITLE
Use epics-containers/ADSimDetector for Pilatus

### DIFF
--- a/.ci/commands.py
+++ b/.ci/commands.py
@@ -1,0 +1,16 @@
+cms.setMetadata()
+%run -i user_TSAXSWAXS.py
+
+sam = SampleGISAXS('test')
+detselect(pilatus2M)
+sam.measureIncidentAngle(0.1, exposure_time=1)
+
+sam.xr(1)
+sam.thr(0.1)
+sam.thabs(0.2)
+
+cms.setMetadata()
+sam.measure(1)
+cms.modeMeasurement()
+wbs()
+sam.measure(1)

--- a/.ci/drop-in.py
+++ b/.ci/drop-in.py
@@ -1,3 +1,5 @@
 caput(beam.mono_bragg_pv, 1.03953)
 sam = SampleGISAXS('test')
 detselect(pilatus2M)
+
+pilatus2M.cam.num_images.put(1)

--- a/iocs/spoof_beamline.py
+++ b/iocs/spoof_beamline.py
@@ -46,6 +46,8 @@ class ReallyDefaultDict(defaultdict):
             return None
         if "XF:11BMB-ES{BS-Ax:" in key:
             return None
+        if "XF:11BMB-ES{Det:PIL2M}" in key:
+            return None
         if (key.endswith('-SP') or key.endswith('-I') or
                 key.endswith('-RB') or key.endswith('-Cmd')):
             key, *_ = key.rpartition('-')


### PR DESCRIPTION
This PR enables using epics-containers' `ADSimDetector` for CMS Pilatus PVs.