### PR TITLE
Add scan_id key to RE to prevent KeyError

### DIFF
--- a/.ci/drop-in.py
+++ b/.ci/drop-in.py
@@ -3,6 +3,6 @@ pilatus2M.tiff.create_directory.set(-20)
 sam = SampleGISAXS('test')
 detselect(pilatus2M)
 
-RE.md.update({'scan_id': 129})
+RE.md.update({'scan_id': 1})
 
 pilatus2M.cam.num_images.put(1)

--- a/.ci/drop-in.py
+++ b/.ci/drop-in.py
@@ -3,4 +3,6 @@ pilatus2M.tiff.create_directory.set(-20)
 sam = SampleGISAXS('test')
 detselect(pilatus2M)
 
+RE.md.update({'scan_id': 129})
+
 pilatus2M.cam.num_images.put(1)


### PR DESCRIPTION
Without the `scan_id` key in there, I get a KeyError. Once updating it, it seems to be saved across sessions, so really it only has to be done once.

@mrakitin suggested adding it to `drop-in.py`